### PR TITLE
Refined numtext function to not use a switch

### DIFF
--- a/oodlebot.js
+++ b/oodlebot.js
@@ -227,30 +227,32 @@ function textToEmotes(t) {
 }
 
 function numText(num) {
-	switch(num) {
-		case '0':
-			return "zero";
-		case '1':
-			return "one";
-		case '2':
-			return "two";
-		case '3':
-			return "three";
-		case '4':
-			return "four";
-		case '5':
-			return "five";
-		case '6':
-			return "six";
-		case '7':
-			return "seven";
-		case '8':
-			return "eight";
-		case '9':
-			return "nine";
-		default:
-			return num;
-	}
+	text = ["zero","one","two","three","four","five","six","seven","eight","nine"];
+	return (text[parseInt(num)] ? text[parseInt(num)]: num);
+	// switch(num) {
+	// 	case '0':
+	// 		return "zero";
+	// 	case '1':
+	// 		return "one";
+	// 	case '2':
+	// 		return "two";
+	// 	case '3':
+	// 		return "three";
+	// 	case '4':
+	// 		return "four";
+	// 	case '5':
+	// 		return "five";
+	// 	case '6':
+	// 		return "six";
+	// 	case '7':
+	// 		return "seven";
+	// 	case '8':
+	// 		return "eight";
+	// 	case '9':
+	// 		return "nine";
+	// 	default:
+	// 		return num;
+	// }
 }
 
 // num = number of messages to delete [2, 100)


### PR DESCRIPTION
Removed large switch case instead for a sleek ternary operation. I left the old function commented out in case you would like to switch between. I tested most cases and they passed when comparing the functionality of this design to old design. :shipit: 